### PR TITLE
Use GetStatus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/env gmake
 
-OASIS_RELEASE := 20.6
-ROSETTA_CLI_RELEASE := 0.2.0
+OASIS_RELEASE := 20.6.1
+ROSETTA_CLI_RELEASE := 0.2.3
 
 OASIS_GO ?= go
 GO := env -u GOPATH $(OASIS_GO)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,53 @@
+#
+# The docker image is built in two stages.  First stage builds the
+# oasis-node and oasis-core-rosetta-gateway binaries.
+# Second stage prepares the execution environment and copies the
+# two binaries over.
+#
+
+#
+# Build stage
+#
+FROM golang:1.13-alpine AS build
+
+# Install prerequisites.
+RUN rm -f /var/cache/apk/*; apk --no-cache add bash git make gcc g++ libressl-dev libseccomp-dev linux-headers
+
+ARG CORE_BRANCH="v20.6.1"
+ARG GATEWAY_BRANCH="master"
+
+# Fetch and build oasis-core.
+RUN git clone --single-branch --branch $CORE_BRANCH https://github.com/oasislabs/oasis-core /usr/local/build-core && \
+	cd /usr/local/build-core/go && \
+	make oasis-node && \
+	cp oasis-node/oasis-node /usr/bin/ && \
+	make clean && go clean -cache -testcache -modcache && \
+	cd / && rm -rf /usr/local/build-core
+
+# Fetch and build oasis-core-rosetta-gateway.
+RUN git clone --single-branch --branch $GATEWAY_BRANCH https://github.com/oasislabs/oasis-core-rosetta-gateway /usr/local/build-gateway && \
+	 cd /usr/local/build-gateway && \
+	 make && \
+	 cp oasis-core-rosetta-gateway /usr/bin/ && \
+	 make nuke && \
+	 cd / && rm -rf /usr/local/build-gateway
+
+
+#
+# Execution stage
+#
+FROM alpine:latest
+RUN rm -f /var/cache/apk/*; apk --no-cache add bash libressl libseccomp
+COPY --from=build /usr/bin/oasis-node /usr/bin/
+COPY --from=build /usr/bin/oasis-core-rosetta-gateway /usr/bin/
+
+VOLUME /data
+WORKDIR /data
+ENV OASIS_NODE_GRPC_ADDR="unix:/data/internal.sock"
+
+# Start the node and the rosetta-gateway.
+CMD oasis-node --config /data/etc/config.yml & oasis-core-rosetta-gateway
+
+# Expose gateway and node ports.
+EXPOSE 8080/tcp
+EXPOSE 26656/tcp

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,37 @@
+# Running Oasis node and gateway in Docker
+
+This directory contains a Dockerfile that builds an image containing both
+the [Oasis node][0] and the [Oasis Rosetta gateway][1], as instructed by the
+[Rosetta requirements][2].
+
+The node should be configured by following the instructions at:
+https://docs.oasis.dev/operators/joining-the-testnet.html
+
+The `/serverdir` in the instructions is equivalent to the `/data` mountpoint
+of the Docker image.
+
+Certain steps are not needed, e.g. provisioning entities and nodes.
+
+You can use the `config.yml` file included in this directory and get the
+`genesis.json` file from the instructions above.
+
+Don't forget to set the proper permissions on the directory you're using as
+the `/data` mountpoint, as well as its subdirectories and files!
+
+To build the Docker image:
+
+	docker build -t oasis-core-rosetta-gateway .
+
+To run the Docker image:
+
+	docker run -v /path/to/your/data:/data -it oasis-core-rosetta-gateway
+
+When run, the Docker image starts the Oasis node and the Oasis Rosetta gateway
+and exposes TCP ports 8080 (gateway) and 26656 (node).
+
+The final image is around 87MB in size.  You can remove the intermediary build
+image to save disk space.
+
+[0]: https://github.com/oasislabs/oasis-core
+[1]: https://github.com/oasislabs/oasis-core-rosetta-gateway
+[2]: https://djr6hkgq2tjcs.cloudfront.net/docs/NodeRequirements.html

--- a/docker/config.yml
+++ b/docker/config.yml
@@ -1,0 +1,31 @@
+##
+# Oasis Node Configuration
+##
+
+datadir: /data
+
+log:
+  level:
+    # Per-module log levels. Longest prefix match will be taken. Fallback to
+    # "default", if no match.
+    default: debug
+    tendermint: debug
+    tendermint/context: error
+  format: JSON
+
+# Path to the genesis file for the current version of the network.
+genesis:
+  file: /data/etc/genesis.json
+
+# Tendermint backend configuration.
+tendermint:
+  abci:
+    prune:
+      strategy: none
+  core:
+    listen_address: tcp://0.0.0.0:26656
+  db:
+    backend: badger
+  p2p:
+    seed:
+      - "D14B9192C94F437E9FA92A755D3CC0341F2E87CF@34.82.86.53:26656"

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ replace github.com/tendermint/tendermint => github.com/oasislabs/tendermint v0.3
 
 require (
 	github.com/coinbase/rosetta-sdk-go v0.1.5
-	github.com/oasislabs/oasis-core/go v0.0.0-20200507164617-35b7f62efec5
+	github.com/oasislabs/oasis-core/go v0.0.0-20200522164651-ba4ecd6c1ecc
 	google.golang.org/grpc v1.29.1
 )

--- a/services/errors.go
+++ b/services/errors.go
@@ -105,7 +105,13 @@ var (
 		Retriable: false,
 	}
 
-	ERROR_LIST = []*types.Error{
+	ErrUnableToGetNodeStatus = &types.Error{
+		Code:      18,
+		Message:   "unable to get node status",
+		Retriable: true,
+	}
+
+	ErrorList = []*types.Error{
 		ErrUnableToGetChainID,
 		ErrInvalidBlockchain,
 		ErrInvalidSubnetwork,
@@ -123,5 +129,6 @@ var (
 		ErrUnableToSubmitTx,
 		ErrUnableToGetNextNonce,
 		ErrMalformedValue,
+		ErrUnableToGetNodeStatus,
 	}
 )

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -103,7 +103,7 @@ gen_burn() {
 		--stake.amount $amount \
 		--transaction.file "$tx" \
 		--transaction.nonce ${NONCE} \
-		--transaction.fee.amount 0 \
+		--transaction.fee.amount 1 \
 		--transaction.fee.gas 10000 \
 		--debug.dont_blame_oasis \
 		--debug.test_entity \
@@ -157,7 +157,7 @@ ${OASIS_ROSETTA_GW} &
 sleep 3
 
 printf "${GRN}### Validating Rosetta gateway implementation...${OFF}\n"
-./rosetta-cli check --end 42 || true
+./rosetta-cli check --end 42
 rm -rf "${ROOT}/validator-data" /tmp/rosetta-cli*
 
 # Clean up after a successful run.


### PR DESCRIPTION
Closes #5, #8.

TODO:
- [x] Genesis height in oasis-net-runner seems to be reported as 0, which we also use as the magic number for the latest block, so we should change the genesis height to 1 in the net runner.
- [x] "Fix" duplicate tx hashes -- tx fees have their own transactions that have the same hash as the transaction that the fee is for, so generate new unique hashes for those in the oasis-client.
- [x] Update to rosetta-cli 0.2.3, which has the exit status fix.
- [x] Add Dockerfile.
- [x] Properly group our txns with same hash into single rosetta txn.
- [x] Wait for a new oasis-core release that has the `GetStatus` stuff and the genesis height fix in it.
